### PR TITLE
Add flag allow params on update

### DIFF
--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -76,6 +76,13 @@ Example:
       params: Object,
 
       /**
+       * Allow the use of query parameters on other requests than GET requests.
+       *
+       * Inherited from parent `rest-api` element.
+       */
+      allowNonGetParams: Boolean,
+
+      /**
        * The model id attribute name. Used for model get and save API requests.
        *
        * Inherited from parent `rest-api` element.
@@ -137,12 +144,7 @@ Example:
        *
        * Inherited from parent `rest-api` element.
        */
-       bubbles: Boolean,
-
-      allowParamsOnUpdates: {
-        type: Boolean,
-        value: false
-      },
+      bubbles: Boolean,
 
       /**
        * The currently selected item of the collection.
@@ -199,7 +201,8 @@ Example:
         'offsetParamName',
         'limitParamName',
         'readOnly',
-        'bubbles'
+        'bubbles',
+        'allowNonGetParams'
       ];
 
       for (var i = 0, prop; prop = inheritedProperties[i]; i++) {
@@ -535,7 +538,7 @@ Example:
 
         if (id) {
 
-          var ajax = this._getAjaxElement(this._getUrlForItemId(id), attrs, !this.allowParamsOnUpdates);
+          var ajax = this._getAjaxElement(this._getUrlForItemId(id), attrs, !this.allowNonGetParams);
           if (!ajax) {
             return;
           }
@@ -544,7 +547,7 @@ Example:
 
         } else {
 
-          var ajax = this._getAjaxElement(null, attrs, !this.allowParamsOnUpdates);
+          var ajax = this._getAjaxElement(null, attrs, !this.allowNonGetParams);
           if (!ajax) {
             return;
           }
@@ -580,7 +583,7 @@ Example:
           return;
         }
 
-        var ajax = this._getAjaxElement(this._getUrlForItemId(id), {}, !this.allowParamsOnUpdates);
+        var ajax = this._getAjaxElement(this._getUrlForItemId(id), {}, !this.allowNonGetParams);
         if (!ajax) {
           return;
         }
@@ -619,12 +622,9 @@ Example:
         return;
       }
 
-      if(!noparams) {
-        try {
-          ajax.params = Object.create(JSON.parse(this.params) || {});
-        } catch (e) {
-          ajax.params = Object.create(this.params || {});
-        }
+      ajax.params = Object.create(this.params || {});
+      if(noparams) {
+        ajax.params = {};
       }
 
       ajax.body = data ? JSON.stringify(data) : '';

--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -613,7 +613,13 @@ Example:
       if (!ajax.url) {
         return;
       }
-      ajax.params = Object.create(this.params || {});
+
+      try {
+        ajax.params = Object.create(JSON.parse(this.params) || {});
+      } catch (e) {
+        ajax.params = Object.create(this.params || {});
+      }
+
       ajax.body = data ? JSON.stringify(data) : '';
       return ajax;
     },

--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -139,6 +139,11 @@ Example:
        */
        bubbles: Boolean,
 
+      allowParamsOnUpdates: {
+        type: Boolean,
+        value: false
+      },
+
       /**
        * The currently selected item of the collection.
        */
@@ -530,7 +535,7 @@ Example:
 
         if (id) {
 
-          var ajax = this._getAjaxElement(this._getUrlForItemId(id), attrs);
+          var ajax = this._getAjaxElement(this._getUrlForItemId(id), attrs, !this.allowParamsOnUpdates);
           if (!ajax) {
             return;
           }
@@ -539,7 +544,7 @@ Example:
 
         } else {
 
-          var ajax = this._getAjaxElement(null, attrs);
+          var ajax = this._getAjaxElement(null, attrs, !this.allowParamsOnUpdates);
           if (!ajax) {
             return;
           }
@@ -575,7 +580,7 @@ Example:
           return;
         }
 
-        var ajax = this._getAjaxElement(this._getUrlForItemId(id));
+        var ajax = this._getAjaxElement(this._getUrlForItemId(id), {}, !this.allowParamsOnUpdates);
         if (!ajax) {
           return;
         }
@@ -607,17 +612,19 @@ Example:
       return collection;
     },
 
-    _getAjaxElement: function(url, data) {
+    _getAjaxElement: function(url, data, noparams) {
       var ajax = this.$.ajax;
       ajax.url = url || this.url;
       if (!ajax.url) {
         return;
       }
 
-      try {
-        ajax.params = Object.create(JSON.parse(this.params) || {});
-      } catch (e) {
-        ajax.params = Object.create(this.params || {});
+      if(!noparams) {
+        try {
+          ajax.params = Object.create(JSON.parse(this.params) || {});
+        } catch (e) {
+          ajax.params = Object.create(this.params || {});
+        }
       }
 
       ajax.body = data ? JSON.stringify(data) : '';

--- a/rest-api.html
+++ b/rest-api.html
@@ -48,6 +48,15 @@ Example:
        */
       params: Object,
 
+
+      /**
+       * Allow the use of query parameters on other requests than GET requests.
+       */
+      allowNonGetParams: {
+        type: Boolean,
+        value: false
+      },
+
       /**
        * The model id attribute name. Used for model get and save API requests.
        *

--- a/test/index.html
+++ b/test/index.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
         'basic-test.html',
+        'params-test.html',
         'inherited-properties.html'
       ]);
     </script>

--- a/test/inherited-properties.html
+++ b/test/inherited-properties.html
@@ -50,7 +50,8 @@
             'offsetParamName',
             'limitParamName',
             'readOnly',
-            'bubbles'
+            'bubbles',
+            'allowNonGetParams'
           ].forEach(function(prop) {
             expect(foos[prop]).to.equal(restApi[prop]);
             expect(foosBars[prop]).to.equal(restApi[prop]);

--- a/test/params-test.html
+++ b/test/params-test.html
@@ -1,0 +1,238 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="../rest-api.html">
+  </head>
+  <body>
+
+    <test-fixture id="rest-api">
+      <template is="dom-template">
+        <rest-api url="{{apiUrl}}" params="{{apiParams}}">
+          <rest-api-resource name="foos">
+            <rest-api-resource name="bars" read-only></rest-api-resource>
+          </rest-api-resource>
+          <rest-api-resource name="bars" no-auto-fetch>
+            <rest-api-resource name="quxes" read-only no-auto-fetch></rest-api-resource>
+          </rest-api-resource>
+        </rest-api>
+      </template>
+    </test-fixture>
+
+    <script>
+
+      var data = {
+        apiUrl: '//rest-api.example.com',
+        foos: [
+          {id: 1},
+          {id: 2},
+          {id: 3}
+        ],
+        bars: [
+          {id: 11, fooId: 1},
+          {id: 12, fooId: 1},
+          {id: 13, fooId: 2}
+        ]
+      };
+
+      function cloneObject(obj) {
+        var clone = {};
+        Object.getOwnPropertyNames(obj).forEach(function(prop) {
+          clone[prop] = obj[prop];
+        });
+        return clone;
+      }
+
+      function getApiUrl(url) {
+        return data.apiUrl + url;
+      }
+
+      var restApi, foos, foosBars, bars, server;
+
+      function createRestApiWithParams(done) {
+        createRestApi(done, true);
+      }
+
+      function createRestApi(done) {
+        var fixtureProperties = {apiUrl: data.apiUrl, apiParams: {customparam: 'value'}};
+        restApi = fixture('rest-api', fixtureProperties);
+        foos = Polymer.dom(restApi).children[0];
+        bars = Polymer.dom(restApi).children[1];
+        foosBars = Polymer.dom(foos).children[0];
+        if (done) {
+          afterServerResponse(foos, done);
+        }
+      }
+
+      function afterServerResponse(target, callback) {
+        var handler = function(event) {
+          target.removeEventListener('response', handler);
+          target.async(callback, 1);
+        };
+        target.addEventListener('response', handler);
+        server.respond();
+      }
+
+      function serverRespondsWithJson(data) {
+        server.respondWith([200, {"Content-Type": "application/json"}, JSON.stringify(data)]);
+      }
+
+      function expectRequest(method, url, body) {
+        var request = server.requests[server.requests.length - 1];
+        expect(request.method).to.equal(method);
+        expect(request.url).to.equal(getApiUrl(url));
+        if (body) {
+          expect(request.requestBody).to.equal(JSON.stringify(body));
+        }
+      }
+
+      beforeEach(function() {
+        server = sinon.fakeServer.create();
+        // Respond data.foos by default
+        serverRespondsWithJson(data.foos);
+      });
+
+      describe('resource', function() {
+
+       describe('CRUD-WITH-PARAMS', function() {
+
+
+          beforeEach(createRestApiWithParams);
+
+
+          it('should auto-fetch collection on name change with params', function(done) {
+
+            serverRespondsWithJson(data.bars);
+
+            foos.name = 'bars';
+
+            expectRequest('GET', '/bars?customparam=value');
+            afterServerResponse(foos, function() {done();});
+          });
+
+          it('should auto-fetch collection on name change with params and allowNonGetParams', function(done) {
+
+            serverRespondsWithJson(data.bars);
+
+            foos.allowNonGetParams = true;
+            foos.name = 'bars';
+
+            expectRequest('GET', '/bars?customparam=value');
+            afterServerResponse(foos, function() {done();});
+          });
+
+
+
+          it('should create new item on collection push with params', function(done) {
+
+            var newObj = {newKey: 'foo'};
+            var newObjOnServer = cloneObject(newObj);
+            newObjOnServer.id = 4;
+            serverRespondsWithJson(newObjOnServer);
+
+            foos.push('collection', newObj);
+
+            expectRequest('POST', '/foos', newObj);
+            afterServerResponse(foos, function() {done();});
+          });
+
+
+          it('should create new item on collection push with params and allowNonGetParams', function(done) {
+
+            var newObj = {newKey: 'foo'};
+            var newObjOnServer = cloneObject(newObj);
+            newObjOnServer.id = 4;
+            serverRespondsWithJson(newObjOnServer);
+
+            foos.allowNonGetParams = true;
+            foos.push('collection', newObj);
+
+            expectRequest('POST', '/foos?customparam=value', newObj);
+            afterServerResponse(foos, function() {done();});
+          });
+
+
+          it('should update the item on key change with params', function(done) {
+
+            var newKey = 'foo';
+            var newKeyOnServer = 'bar';
+            serverRespondsWithJson({newKey: newKeyOnServer});
+
+            foos.set('collection.0.newKey', newKey)
+
+            expectRequest('PATCH', '/foos/' + data.foos[0].id, {newKey: newKey});
+            afterServerResponse(foos, function() {done();});
+          });
+
+          it('should update the item on key change with params and allowNonGetParams', function(done) {
+
+            var newKey = 'foo';
+            var newKeyOnServer = 'bar';
+            serverRespondsWithJson({newKey: newKeyOnServer});
+
+            foos.allowNonGetParams = true;
+            foos.set('collection.0.newKey', newKey)
+
+            expectRequest('PATCH', '/foos/' + data.foos[0].id + '?customparam=value', {newKey: newKey});
+            afterServerResponse(foos, function() {done();});
+          });
+
+          it('should update the item on replace with params', function(done) {
+
+            var newItem = cloneObject(data.foos[0]);
+            newItem.newKey = 'foo';
+            var newItemOnServer = cloneObject(newItem);
+            newItemOnServer.newKey = 'bar';
+            serverRespondsWithJson(newItemOnServer);
+
+            foos.set('collection.0', newItem);
+
+            expectRequest('PUT', '/foos/' + data.foos[0].id, newItem);
+            afterServerResponse(foos, function() {done();});
+          });
+
+          it('should update the item on replace with params and allowNonGetParams', function(done) {
+
+            var newItem = cloneObject(data.foos[0]);
+            newItem.newKey = 'foo';
+            var newItemOnServer = cloneObject(newItem);
+            newItemOnServer.newKey = 'bar';
+            serverRespondsWithJson(newItemOnServer);
+
+            foos.allowNonGetParams = true;
+            foos.set('collection.0', newItem);
+
+            expectRequest('PUT', '/foos/' + data.foos[0].id + '?customparam=value', newItem);
+            afterServerResponse(foos, function() {done();});
+          });
+
+
+          it('should destroy item with params', function(done) {
+
+            foos.pop('collection');
+
+            expectRequest('DELETE', '/foos/' + data.foos[data.foos.length - 1].id);
+            afterServerResponse(foos, function() {done();});
+          });
+
+          it('should destroy item with params and allowNonGetParams', function(done) {
+
+            foos.allowNonGetParams = true;
+            foos.pop('collection');
+
+            expectRequest('DELETE', '/foos/' + data.foos[data.foos.length - 1].id + '?customparam=value');
+            afterServerResponse(foos, function() {done();});
+          });
+
+        });
+      });
+
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
This is an continuation of the last pull request.
I found in my development that the json-server I use for testing didn't allow that you had parameters on PATCH, POST and DELETE calls so I added a flag to allowParamsOnUpdate to handle this issue.

The default is useful for me, but I'm open for discussion if the default should be to allow this behavior so  I have to turn it of when testing. But I see it as a useful feature to have.
