### PR TITLE
Added link to API documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A Polymer element providing declarative data bindings to REST API.
 
 ## Live demo
 
+API documentation could be found at [API Doc](https://platosha.github.io/rest-api/components/rest-api/)
+
 Check the [Albums Demo](http://platosha.github.io/rest-api/components/rest-api/demo/index.html), the fully declarative albums browser which uses [JSON Placeholder API](http://jsonplaceholder.typicode.com/).
 
 ## Install


### PR DESCRIPTION
I looked at the README looking for the API documentation to understand the component better but was missing the link. After some digging I found it by changing URL from the demo page. I thought it might be a good idea to advertise this page better so more people could use the component.
