### PR TITLE
Propagate the changes to the selected item to the collection.

### DIFF
--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -233,6 +233,7 @@ Example:
 
     observers: [
       '_collectionChanged(collection.*)',
+      '_selectedItemChanged(selectedItem.*)',
       '_autoFetch(url, collection, params.*)'
     ],
 
@@ -272,6 +273,12 @@ Example:
 
       changes.indexSplices.forEach(processer);
 
+    },
+
+    _selectedItemChanged: function(changeRecord) {
+      var key = this._polymerCollection.getKey(changeRecord.base);
+      var attribKey = changeRecord.path.split('.').slice(1);
+      this.set(['collection', key, attribKey], changeRecord.base[attribKey]);
     },
 
     _collectionChanged: function(changeRecord) {


### PR DESCRIPTION
Realized when I used the new feature to select a specific item via ID that when I changed the values of the items these changes did not propagate to the collection and therefor did not send a change to the backend server.
