### PR TITLE
Added headers passthru on rest-api-resource.

### DIFF
--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -78,6 +78,11 @@ Example:
       },
 
       /**
+       * The set of request headers used for this resource’s API requests.
+       */
+      headers: Object,
+
+      /**
        * Default set of request parameters used in all API requests.
        *
        * Inherited from the `params` parameter of the parent `rest-api` element.
@@ -206,6 +211,7 @@ Example:
     attached: function() {
       var inheritedProperties = [
         'idAttribute',
+        'headers',
         'offsetParamName',
         'limitParamName',
         'readOnly',
@@ -640,6 +646,7 @@ Example:
         }, this);
       }
 
+      ajax.headers = Object.create(this.headers || {});
       ajax.body = data ? JSON.stringify(data) : '';
       return ajax;
     },

--- a/rest-api.html
+++ b/rest-api.html
@@ -48,6 +48,12 @@ Example:
        */
       params: Object,
 
+      /**
+       * Default set of request headers used in all API requests.
+       *
+       * Inherited by child `rest-api-resource` elements.
+       */
+      headers: Object,
 
       /**
        * Allow the use of query parameters on other requests than GET requests.


### PR DESCRIPTION
We needed some headers for authentication on our application and I added a simple implementation to pass these headers through to the iron-ajax object.
