### PR TITLE
Fetch single item from selectedItemId

### DIFF
--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -166,7 +166,7 @@ Example:
       /**
        * The id of the currently selected item of the collection.
        */
-      selectedId: {
+      selectedItemId: {
         type: String,
         notify: true,
         observer: '_changedSelectedId'
@@ -267,8 +267,8 @@ Example:
       return url + '/' + name;
     },
 
-    _changedSelectedId: function(selectedId) {
-      this.selectedItem = this._collectionById[selectedId];
+    _changedSelectedId: function(selectedItemId) {
+      this.selectedItem = this._collectionById[selectedItemId];
     },
 
     _forEachAddedAndRemovedItem: function(changes, addedItemCallback, removedItemCallback) {
@@ -446,7 +446,7 @@ Example:
     _replaceCollection: function(items) {
       this._spliceCollection(0, this.collection.length, items);
 
-      if(this.selectedId) this._changedSelectedId(this.selectedId);
+      if(this.selectedItemId) this._changedSelectedId(this.selectedItemId);
     },
 
     _getItemId: function(item) {

--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -164,6 +164,15 @@ Example:
       },
 
       /**
+       * The id of the currently selected item of the collection.
+       */
+      selectedId: {
+        type: String,
+        notify: true,
+        observer: '_changedSelectedId'
+      },
+
+      /**
        * Used in nested request and represents the currently selected item of
        * the parent.
        */
@@ -256,6 +265,10 @@ Example:
       }
 
       return url + '/' + name;
+    },
+
+    _changedSelectedId: function(selectedId) {
+      this.selectedItem = this._collectionById[selectedId];
     },
 
     _forEachAddedAndRemovedItem: function(changes, addedItemCallback, removedItemCallback) {
@@ -432,6 +445,8 @@ Example:
 
     _replaceCollection: function(items) {
       this._spliceCollection(0, this.collection.length, items);
+
+      if(this.selectedId) this._changedSelectedId(this.selectedId);
     },
 
     _getItemId: function(item) {

--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -78,6 +78,11 @@ Example:
       },
 
       /**
+       * The set of request headers used for this resource’s API requests.
+       */
+      headers: Object,
+
+      /**
        * Default set of request parameters used in all API requests.
        *
        * Inherited from the `params` parameter of the parent `rest-api` element.
@@ -215,6 +220,7 @@ Example:
     attached: function() {
       var inheritedProperties = [
         'idAttribute',
+        'headers',
         'offsetParamName',
         'limitParamName',
         'readOnly',
@@ -655,6 +661,7 @@ Example:
         }, this);
       }
 
+      ajax.headers = Object.create(this.headers || {});
       ajax.body = data ? JSON.stringify(data) : '';
       return ajax;
     },

--- a/rest-api-resource.html
+++ b/rest-api-resource.html
@@ -154,6 +154,12 @@ Example:
       readOnly: Boolean,
 
       /**
+       * Enables single item fetching. Example fetch http://www.domain.com/post/1
+       * when selectedItemId = 1 is specified and add the item to an empty collection.
+       */
+      fetchSingle: Boolean,
+
+      /**
        * Enable bubbling for `error`, `request` and `response` events.
        *
        * Inherited from parent `rest-api` element.
@@ -518,9 +524,22 @@ Example:
           return;
         }
 
+        if (this.fetchSingle && this.selectedItemId) {
+          ajax.url = ajax.url + '/' + this.selectedItemId;
+        }
+
         var request = ajax.generateRequest();
+
         request.completes.then(function(request) {
-          this._replaceCollection(request.response);
+
+          var newCollection = [];
+          if (this.fetchSingle && this.selectedItemId) {
+            newCollection.push(request.response);
+          } else {
+            newCollection = request.response;
+          }
+
+          this._replaceCollection(newCollection);
         }.bind(this));
 
         return request;

--- a/rest-api.html
+++ b/rest-api.html
@@ -48,6 +48,12 @@ Example:
        */
       params: Object,
 
+      /**
+       * Default set of request headers used in all API requests.
+       *
+       * Inherited by child `rest-api-resource` elements.
+       */
+      headers: Object,
 
       /**
        * Allow the use of query parameters on other requests than GET requests.


### PR DESCRIPTION
Builds on PR #10 

I realized that it would be nice to be able to fetch a single item from a resource collection when editing or building structured fetching. In this pull request I add an extra variable called fetch-single that you could use to get only the item that selectedItemId points to.

So for example of posts at www.domain.com/posts

When selectedItemId = 1 the get would fetch www.domain.com/posts/1 and then create an empty collection, add the single item to that collection and replace the working collection with this new one.
